### PR TITLE
Docs: fix links to API endpoints

### DIFF
--- a/Frontend/legacy/src/App.tsx
+++ b/Frontend/legacy/src/App.tsx
@@ -30,7 +30,7 @@
 //       }}
 //     >
 //       <div style={{ marginBottom: "1rem", color: "#38bdf8" }}>
-//         curl https://api.ipwho.org/json/8.8.8.8
+//         curl https://ipwho.org/ip/8.8.8.8
 //       </div>
 //       <motion.div
 //         initial={{ opacity: 0 }}
@@ -122,7 +122,7 @@ export function App() {
                 transition={{delay: 0.2, duration: 0.4}}
                 style={{color: "#38bdf8", marginBottom: "1rem"}}
             >
-                curl https://api.ipwho.org/json/8.8.8.8
+                curl https://ipwho.org/ip/8.8.8.8
             </motion.div>
 
             {displayedLines.map((line, i) => (

--- a/Frontend/legacy/src/Docs/components/BaseURL.tsx
+++ b/Frontend/legacy/src/Docs/components/BaseURL.tsx
@@ -45,33 +45,33 @@ export function BaseURL() {
                 <pre>
                     Get your own IP info:
                     <SyntaxHighlighter language={'https'} style={a11yDark}>
-                        {"GET https://api.ipwho.org/me"}
+                        {"GET https://ipwho.org/me"}
                     </SyntaxHighlighter>
                     Get info for a specific IP:
                     <SyntaxHighlighter language={'https'} style={a11yDark}>
-                        {"GET https://api.ipwho.org/8.8.8.8"}
+                        {"GET https://ipwho.org/ip/8.8.8.8"}
                     </SyntaxHighlighter>
                     Filter response (only country, city, currency):
                     <SyntaxHighlighter language={'https'} style={a11yDark}>
-                        {"GET https://api.ipwho.org/8.8.8.8?get=country,city,currency"}
+                        {"GET https://ipwho.org/ip/8.8.8.8?get=country,city,currency"}
                     </SyntaxHighlighter>
                     Bulk lookup:
                     <SyntaxHighlighter language={'https'} style={a11yDark}>
-                        {"GET https://api.ipwho.org/bulk/8.8.8.8,1.1.1.1"}
+                        {"GET https://ipwho.org/bulk/8.8.8.8,1.1.1.1"}
                     </SyntaxHighlighter>
                 </pre>
 
                 <h3>JavaScript Fetch Example</h3>
                 <pre>
                     <SyntaxHighlighter language="javascript" style={a11yDark}>
-                        {`fetch('https://api.ipwho.org/8.8.8.8?get=country,city,currency')\n.then(res => res.json())\n.then(data => console.log(data));`}
+                        {`fetch('https://ipwho.org/ip/8.8.8.8?get=country,city,currency')\n.then(res => res.json())\n.then(data => console.log(data));`}
                     </SyntaxHighlighter>
                 </pre>
 
                 <h3>cURL Examples</h3>
                 <pre>
                     <SyntaxHighlighter language="bash" style={a11yDark}>
-                        {`curl "https://api.ipwho.org/me"\ncurl "https://api.ipwho.org/1.1.1.1"\ncurl "https://api.ipwho.org/1.1.1.1?get=country,city"\ncurl "https://api.ipwho.org/bulk/1.1.1.1,8.8.8.8"`}
+                        {`curl "https://ipwho.org/me"\ncurl "https://ipwho.org/ip/1.1.1.1"\ncurl "https://ipwho.org/ip/1.1.1.1?get=country,city"\ncurl "https://ipwho.org/bulk/1.1.1.1,8.8.8.8"`}
                     </SyntaxHighlighter>
 </pre>
             </div>

--- a/Frontend/src/react-app/Docs/components/BaseURL.tsx
+++ b/Frontend/src/react-app/Docs/components/BaseURL.tsx
@@ -45,33 +45,33 @@ export function BaseURL() {
                 <pre>
                     Get your own IP info:
                     <SyntaxHighlighter language={'https'} style={a11yDark}>
-                        {"GET https://api.ipwho.org/me"}
+                        {"GET https://ipwho.org/me"}
                     </SyntaxHighlighter>
                     Get info for a specific IP:
                     <SyntaxHighlighter language={'https'} style={a11yDark}>
-                        {"GET https://api.ipwho.org/8.8.8.8"}
+                        {"GET https://ipwho.org/ip/8.8.8.8"}
                     </SyntaxHighlighter>
                     Filter response (only country, city, currency):
                     <SyntaxHighlighter language={'https'} style={a11yDark}>
-                        {"GET https://api.ipwho.org/8.8.8.8?get=country,city,currency"}
+                        {"GET https://ipwho.org/ip/8.8.8.8?get=country,city,currency"}
                     </SyntaxHighlighter>
                     Bulk lookup:
                     <SyntaxHighlighter language={'https'} style={a11yDark}>
-                        {"GET https://api.ipwho.org/bulk/8.8.8.8,1.1.1.1"}
+                        {"GET https://ipwho.org/bulk/8.8.8.8,1.1.1.1"}
                     </SyntaxHighlighter>
                 </pre>
 
                 <h3>JavaScript Fetch Example</h3>
                 <pre>
                     <SyntaxHighlighter language="javascript" style={a11yDark}>
-                        {`fetch('https://api.ipwho.org/8.8.8.8?get=country,city,currency')\n.then(res => res.json())\n.then(data => console.log(data));`}
+                        {`fetch('https://ipwho.org/ip/8.8.8.8?get=country,city,currency')\n.then(res => res.json())\n.then(data => console.log(data));`}
                     </SyntaxHighlighter>
                 </pre>
 
                 <h3>cURL Examples</h3>
                 <pre>
                     <SyntaxHighlighter language="bash" style={a11yDark}>
-                        {`curl "https://api.ipwho.org/me"\ncurl "https://api.ipwho.org/1.1.1.1"\ncurl "https://api.ipwho.org/1.1.1.1?get=country,city"\ncurl "https://api.ipwho.org/bulk/1.1.1.1,8.8.8.8"`}
+                        {`curl "https://ipwho.org/me"\ncurl "https://ipwho.org/ip/1.1.1.1"\ncurl "https://ipwho.org/ip/1.1.1.1?get=country,city"\ncurl "https://ipwho.org/bulk/1.1.1.1,8.8.8.8"`}
                     </SyntaxHighlighter>
 </pre>
             </div>


### PR DESCRIPTION
In the docs we have some wrong examples:
1. https://api.ipwho.org/me doesn't work: did you mean https://ipwho.org/me instead?
2. https://api.ipwho.org/json/8.8.8.8 doesn't work: did you mean https://ipwho.org/ip/8.8.8.8 instead?
3. https://api.ipwho.org/bulk/8.8.8.8,1.1.1.1 doesn't work: did you mean https://ipwho.org/bulk/8.8.8.8,1.1.1.1 instead? If so, even https://ipwho.org/bulk/8.8.8.8,1.1.1.1 doesn't work: we have this response:
   ```json
   {
      "success": false,
      "message": "Failed"
   }
   ```
